### PR TITLE
Add view and procedure to handle missing dimension slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ In the `views/` directory, there is a number of views that can be
 useful. The views are typically added as separate files to allow you
 to just include the views that you're interested in.
 
-`chunks.sql`
+`views/chunks.sql`
 : Defines views to get information about the time ranges and tablespace for chunks.
+
+`views/missing_dimension_slices.sql`
+: Defines a view `missing_dimension_slices` to check for missing dimension slices.
+
+## Procedures
+
+`procs/repair_dimension_slice.sql`
+: Procedure `repair_dimension_slice` that will repair the `dimension_slice` table if it missing slices.
 
 ## Documentation and Help
 

--- a/procs/repair_dimension_slices.sql
+++ b/procs/repair_dimension_slices.sql
@@ -1,0 +1,87 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE and LICENSE for copyright and licensing information.
+
+DROP PROCEDURE IF EXISTS repair_dimension_slice;
+
+-- Due to a bug in versions before TimescaleDB 1.7.5 dimension slices
+-- could be removed resulting in broken dependencies. This procedure
+-- will repair the dimension_slice table by recreating missing
+-- dimension slices. If the dimension slice table is broken and there
+-- are dimension slices missing from the table, we will repair it by:
+--
+--    1. Finding all chunk constraints that have missing dimension
+--       slices and extract the constraint expression from the
+--       associated constraint.
+--       
+--    2. Parse the constraint expression and extract the column name,
+--       and upper and lower range values as text.
+--       
+--    3. Use the column type to construct the range values (UNIX
+--       microseconds) from these values.
+CREATE PROCEDURE repair_dimension_slice()
+LANGUAGE SQL
+AS $BODY$
+INSERT INTO _timescaledb_catalog.dimension_slice
+WITH
+   -- All dimension slices that are mentioned in the chunk_constraint
+   -- table but are missing from the dimension_slice table.
+   missing_slices AS (
+      SELECT hypertable_id,
+      	     chunk_id,
+	     dimension_slice_id,
+	     constraint_name,
+	     attname AS column_name,
+	     pg_get_expr(conbin, conrelid) AS constraint_expr
+      FROM _timescaledb_catalog.chunk_constraint cc
+      JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+      JOIN pg_constraint ON conname = constraint_name
+      JOIN pg_namespace ns ON connamespace = ns.oid AND ns.nspname = ch.schema_name
+      JOIN pg_attribute ON attnum = conkey[1] AND attrelid = conrelid
+      WHERE
+	 dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice)
+   ),
+
+  -- Unparsed range start and end for each dimension slice id that
+  -- is missing.
+   unparsed_missing_slices AS (
+      SELECT di.id AS dimension_id,
+      	     dimension_slice_id,
+             constraint_name,
+	     column_type,
+	     column_name,
+	     (SELECT SUBSTRING(constraint_expr, $$>=\s*'?([\w\d\s:+-]+)'?$$)) AS range_start,
+	     (SELECT SUBSTRING(constraint_expr, $$<\s*'?([\w\d\s:+-]+)'?$$)) AS range_end
+	FROM missing_slices JOIN _timescaledb_catalog.dimension di USING (hypertable_id, column_name)
+   )
+SELECT DISTINCT
+       dimension_slice_id,
+       dimension_id,
+       CASE
+       WHEN column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamptz)
+       WHEN column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamp)
+       WHEN column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::date)
+       ELSE
+       	    CASE
+	    WHEN range_start IS NULL
+	    THEN -9223372036854775808
+	    ELSE _timescaledb_internal.time_to_internal(range_start::bigint)
+	    END
+       END AS range_start,
+       CASE 
+       WHEN column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamptz)
+       WHEN column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamp)
+       WHEN column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::date)
+       ELSE
+       	    CASE WHEN range_end IS NULL
+	    THEN 9223372036854775807
+	    ELSE _timescaledb_internal.time_to_internal(range_end::bigint)
+	    END
+       END AS range_end
+  FROM unparsed_missing_slices;
+$BODY$;

--- a/views/missing_dimension_slices.sql
+++ b/views/missing_dimension_slices.sql
@@ -1,0 +1,31 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE and LICENSE for copyright and licensing information.
+
+DROP VIEW IF EXISTS missing_dimension_slices;
+
+-- Due to a bug in versions before TimescaleDB 1.7.5 dimension slices
+-- could be removed resulting in broken dependencies. This view list
+-- any such missing slices and also show the associated constraint.
+--
+-- This can be used to re-construct the missing dimension slices,
+-- which is done in the repair_dimension_slices procedure in
+-- procs/repair_dimension_slices.sql
+CREATE VIEW missing_dimension_slices AS
+SELECT DISTINCT
+    format('%I.%I', ht.schema_name, ht.table_name)::regclass AS hypertable,
+    format('%I.%I', ch.schema_name, ch.table_name)::regclass AS chunk,
+    attname AS column_name,
+    dimension_slice_id,
+    constraint_name,
+    pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM
+    _timescaledb_catalog.chunk_constraint cc
+    JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+    JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+    JOIN pg_constraint ON conname = constraint_name
+    JOIN pg_namespace ns ON connamespace = ns.oid
+        AND ns.nspname = ch.schema_name
+    JOIN pg_attribute ON attnum = conkey[1]
+        AND attrelid = conrelid
+WHERE
+    dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);


### PR DESCRIPTION
Due to a bug in versions prior to 1.7.5, dimension slices could be
removed when running insert and `drop_chunks` concurrently. This commit
contain a script to re-construct such missing dimension slices as well
as a view to show any missing slices and what hypertables and chunks
they affect.

See timescale/timescaledb#1986