### PR TITLE
DO UPDATE support for backfill operations

### DIFF
--- a/backfill.sql
+++ b/backfill.sql
@@ -191,7 +191,7 @@ BEGIN
 
     IF on_conflict_action == 'DoNothing' THEN
         on_conflict_clause = 'ON CONFLICT DO NOTHING';
-    ELSE IF on_conflict_action == 'Update' THEN
+    ELSEIF on_conflict_action == 'Update' THEN
         on_conflict_clause = 'ON CONFLICT DO UPDATE SET ';
         FOR on_conflict_index IN 1 .. ARRAY_LENGTH(update_action_columns, 1) LOOP
             on_conflict_column = update_action_columns[on_conflict_index];

--- a/backfill.sql
+++ b/backfill.sql
@@ -189,13 +189,13 @@ BEGIN
             $$;
     END IF;
 
-    IF on_conflict_action == 'DoNothing' THEN
+    IF on_conflict_action = 'DoNothing' THEN
         on_conflict_clause = 'ON CONFLICT DO NOTHING';
-    ELSEIF on_conflict_action == 'Update' THEN
+    ELSEIF on_conflict_action = 'Update' THEN
         on_conflict_clause = 'ON CONFLICT DO UPDATE SET ';
         FOR on_conflict_index IN 1 .. ARRAY_LENGTH(update_action_columns, 1) LOOP
             on_conflict_column = update_action_columns[on_conflict_index];
-            on_conflict_clause = on_conflict_clause || FORMAT('%%5$s.%1$I = to_insert.%1$I', on_conflict_column);
+            on_conflict_clause = on_conflict_clause || FORMAT('%2$s.%1$I = to_insert.%1$I', on_conflict_column, dest);
             IF on_conflict_index < ARRAY_LENGTH(update_action_columns, 1) THEN
                 on_conflict_clause = on_conflict_clause || ', ';
             END IF;

--- a/backfill.sql
+++ b/backfill.sql
@@ -29,6 +29,10 @@
 * of that table in certain ranges faster. (ie `CREATE INDEX ON cpu_temp(time);`)
 */
 
+---- Backfill operation enum type to define the behavior in case of conflicting rows
+DROP TYPE IF EXISTS BackfillOnConflict;
+CREATE TYPE BackfillOnConflict AS ENUM ('DoNothing', 'Update', 'Error');
+
 ---- Some helper functions and procedures before the main event
 CREATE OR REPLACE FUNCTION get_schema_and_table_name(IN regclass, OUT nspname name, OUT relname name) AS $$
     SELECT n.nspname, c.relname  


### PR DESCRIPTION
The current backfill script only supports errors on duplicate rows or a _DO NOTHING_ clause. This pull request provides a first draft of general support for column updates in backfill operations.

Columns to update can be passed to the function using the new parameter update_action_columns as `array['column1', 'column2', ...]` and are used to generate the actual DO UPDATE SET clause when on_conflict_action is set to 'Update'.