### PR TITLE
allow raw on conflict statement

### DIFF
--- a/backfill.sql
+++ b/backfill.sql
@@ -211,6 +211,9 @@ BEGIN
     ELSEIF UPPER(on_conflict_action) = 'UPDATE' THEN
         SELECT 'ON CONFLICT ' || on_conflict_target || ' DO UPDATE SET ' || STRING_AGG(FORMAT('%1$I = EXCLUDED.%1$I', on_conflict_update_column), ', ')
         FROM UNNEST(on_conflict_update_columns) AS on_conflict_update_column INTO on_conflict_clause;
+    ELSEIF UPPER(on_conflict_action) = 'UPDATE_RAW' THEN
+        SELECT 'ON CONFLICT ' || on_conflict_target || ' DO UPDATE SET ' || STRING_AGG(FORMAT('%s', on_conflict_update_column), ', ')
+        FROM UNNEST(on_conflict_update_columns) AS on_conflict_update_column INTO on_conflict_clause;
     END IF;
 
     --Loop through the dimension slices that that are impacted


### PR DESCRIPTION
Signed-off-by: Matthias Glaub <maglnet@users.noreply.github.com>

I had the case where I needed to merge jsonb values done within the `ON CONFLICT` clause.
e.g.:

```
ON CONFLICT (time, location) UPDATE SET data = original.data::jsonb || excluded.data::jsonb
```

With the provided PR this is now possible as follows:
```
 CALL decompress_backfill(
                staging_table=>'temp_staging',
                destination_hypertable=> 'original',
                on_conflict_action=>  'UPDATE_RAW',
                on_conflict_target=> '(time, location)',
                on_conflict_update_columns=> ARRAY['data = original.data || excluded.data::jsonb']
            );
```

