### PR TITLE
Remove time_literal_sql dependency

### DIFF
--- a/migrate.sql
+++ b/migrate.sql
@@ -37,6 +37,37 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
+-- Gets the sql code for representing the literal for the given time value (in the internal representation) as the column_type.
+CREATE OR REPLACE FUNCTION time_literal_sql(
+    time_value      BIGINT,
+    column_type     REGTYPE
+)
+    RETURNS text LANGUAGE PLPGSQL STABLE AS
+$BODY$
+DECLARE
+    ret text;
+BEGIN
+    IF time_value IS NULL THEN
+        RETURN format('%L', NULL);
+    END IF;
+    CASE column_type
+      WHEN 'BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype THEN
+        RETURN format('%L', time_value); -- scale determined by user.
+      WHEN 'TIMESTAMP'::regtype THEN
+        --the time_value for timestamps w/o tz does not depend on local timezones. So perform at UTC.
+        RETURN format('TIMESTAMP %1$L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))); -- microseconds
+      WHEN 'TIMESTAMPTZ'::regtype THEN
+        -- assume time_value is in microsec
+        RETURN format('TIMESTAMPTZ %1$L', _timescaledb_internal.to_timestamp(time_value)); -- microseconds
+      WHEN 'DATE'::regtype THEN
+        RETURN format('%L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))::date);
+      ELSE
+         EXECUTE 'SELECT format(''%L'', $1::' || column_type::text || ')' into ret using time_value;
+         RETURN ret;
+    END CASE;
+END
+$BODY$ SET search_path TO pg_catalog, pg_temp;
+
 CREATE OR REPLACE FUNCTION make_log_table(log_table_name NAME,  
     parallel_worker_num int, 
     source_table regclass,
@@ -166,8 +197,8 @@ BEGIN
     END IF;
 
     WHILE NOT done LOOP 
-        r_start = _timescaledb_internal.time_literal_sql(next_row.start_t, sink_dim.column_type);
-        r_end = _timescaledb_internal.time_literal_sql(next_row.end_t, sink_dim.column_type);
+        r_start = time_literal_sql(next_row.start_t, sink_dim.column_type);
+        r_end = time_literal_sql(next_row.end_t, sink_dim.column_type);
         RAISE DEBUG '% Moving times FROM % to % worker %', now(), r_start, r_end, parallel_worker_num +1;
         EXECUTE FORMAT(move_statement,  r_start, r_end);
         GET DIAGNOSTICS affected = ROW_COUNT;


### PR DESCRIPTION
Don't use the internal time_literal_sql function coming with timescaledb but provide our own implementation. The time_literal_sql function from timescaledb is going to be removed in a future version so to not depend on this function we provide our own implementation.