### PR TITLE
Incremental CAgg refreshes for tiered data

### DIFF
--- a/utils/osm_incremental_cagg_refresh/01-producer.sql
+++ b/utils/osm_incremental_cagg_refresh/01-producer.sql
@@ -1,0 +1,187 @@
+CREATE SCHEMA IF NOT EXISTS _timescaledb_additional;
+
+CREATE TABLE IF NOT EXISTS _timescaledb_additional.incremental_continuous_aggregate_refreshes (
+    id bigint GENERATED ALWAYS AS IDENTITY,
+    continuous_aggregate regclass not null,
+    window_start timestamptz not null,
+    window_end timestamptz not null CHECK (window_end > window_start),
+    scheduled timestamptz not null default pg_catalog.clock_timestamp(),
+    priority int not null default 1,
+    started timestamptz,
+    finished timestamptz,
+    worker_pid integer,
+    primary key (id),
+    CONSTRAINT incr_cagg_refreshes_workers_have_started CHECK (num_nulls(worker_pid, started) IN (0, 2))
+);
+
+GRANT USAGE ON SCHEMA _timescaledb_additional TO public;
+REVOKE ALL ON TABLE _timescaledb_additional.incremental_continuous_aggregate_refreshes FROM PUBLIC;
+GRANT SELECT ON TABLE _timescaledb_additional.incremental_continuous_aggregate_refreshes TO public;
+GRANT ALL ON TABLE _timescaledb_additional.incremental_continuous_aggregate_refreshes TO pg_database_owner;
+
+COMMENT ON COLUMN _timescaledb_additional.incremental_continuous_aggregate_refreshes.worker_pid IS
+$$This column will be populated with the pid that is currently running this task.
+This allows us to keep track of things, as well as allow us to reschedule an item if
+a worker_pid is no longer active (for whatever reason)$$;
+
+COMMENT ON COLUMN _timescaledb_additional.incremental_continuous_aggregate_refreshes.scheduled IS
+$$To ensure we do actually get to do all the work, the workers will always pick up the
+task that has the lowest priority, and then which one was scheduled first.
+In that way, we have a bit of a priority queue.$$;
+
+-- We want to avoid scheduling the same thing twice, for those tasks that have not yet been
+-- picked up by any worker.
+CREATE UNIQUE INDEX IF NOT EXISTS incr_cagg_refreshes_distinct_tasks_unq ON _timescaledb_additional.incremental_continuous_aggregate_refreshes(
+    continuous_aggregate,
+    window_start,
+    window_end
+) WHERE worker_pid IS NULL AND finished IS NULL;
+
+CREATE INDEX IF NOT EXISTS incr_cagg_refreshes_find_first_work_item_idx ON _timescaledb_additional.incremental_continuous_aggregate_refreshes(
+    priority,
+    scheduled
+) WHERE worker_pid IS NULL;
+
+CREATE INDEX IF NOT EXISTS incr_cagg_refreshes_active_workers_idx ON _timescaledb_additional.incremental_continuous_aggregate_refreshes(
+    worker_pid
+) WHERE worker_pid IS NOT NULL;
+
+-- Calculate the time bucket using the continuous aggregate bucket function configuration
+CREATE OR REPLACE FUNCTION _timescaledb_additional.cagg_time_bucket(INTEGER, TIMESTAMPTZ)
+RETURNS TIMESTAMPTZ AS
+$$
+DECLARE
+    params TEXT[];
+    stmt TEXT;
+    r RECORD;
+    result TIMESTAMPTZ;
+BEGIN
+    SELECT
+        *
+    INTO
+        r
+    FROM
+        _timescaledb_catalog.continuous_aggs_bucket_function
+    WHERE
+        mat_hypertable_id = $1;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Continuous Aggregate % not found', $1;
+    END IF;
+
+    params := array_append(params, format('%I => %L::timestamptz', 'ts', $2));
+
+    IF r.bucket_width IS NOT NULL THEN
+        params := array_append(params, format('%I => %L::interval', 'bucket_width', r.bucket_width));
+    END IF;
+
+    IF r.bucket_origin IS NOT NULL THEN
+        params := array_append(params, format('%I => %L::timestamptz', 'origin', r.bucket_origin));
+    END IF;
+
+    IF r.bucket_offset IS NOT NULL THEN
+        params := array_append(params, format('%I => %L::interval', 'offset', r.bucket_offset));
+    END IF;
+
+    IF r.bucket_timezone IS NOT NULL THEN
+        params := array_append(params, format('%I => %L::text', 'timezone', r.bucket_timezone));
+    END IF;
+
+    stmt := format('SELECT time_bucket(%s)', array_to_string(params, ', '));
+    RAISE DEBUG '%', stmt;
+
+    EXECUTE stmt
+    INTO result;
+
+    RETURN result;
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_additional.schedule_osm_cagg_refresh(
+    schema_mask TEXT DEFAULT '%',
+    name_mask TEXT DEFAULT '%',
+    priority INTEGER DEFAULT 1
+) AS
+$$
+BEGIN
+    -- Find caggs built on top of tiered hypertables
+    INSERT INTO _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+    SELECT
+        mat_hypertable_id,
+        ((extract(epoch from _timescaledb_additional.cagg_time_bucket(cagg.mat_hypertable_id, MIN(range_start)))) * 1000000)::bigint AS invalidation_start,
+        ((extract(epoch from _timescaledb_additional.cagg_time_bucket(cagg.mat_hypertable_id, MAX(range_end)) + (bf.bucket_width::interval + interval '1 millisecond')))* 1000000)::bigint AS invalidation_end
+    FROM
+        timescaledb_osm.tiered_chunks tch
+        JOIN _timescaledb_catalog.hypertable ht ON (tch.hypertable_name = ht.table_name AND tch.hypertable_schema = ht.schema_name)
+        JOIN _timescaledb_catalog.continuous_agg cagg ON (cagg.raw_hypertable_id = ht.id)
+        JOIN _timescaledb_catalog.continuous_aggs_bucket_function bf USING (mat_hypertable_id)
+    WHERE
+        user_view_schema LIKE name_mask
+        AND user_view_name LIKE name_mask
+    GROUP BY
+        mat_hypertable_id, bf.bucket_width;
+
+    -- schedule the refresh for given interval
+    INSERT INTO _timescaledb_additional.incremental_continuous_aggregate_refreshes
+        (continuous_aggregate, window_start, window_end, priority)
+    SELECT
+        format('%I.%I', cagg.user_view_schema, cagg.user_view_name)::regclass,
+        _timescaledb_additional.cagg_time_bucket(cagg.mat_hypertable_id, range_start) AS window_start,
+        _timescaledb_additional.cagg_time_bucket(cagg.mat_hypertable_id, range_end) + (bf.bucket_width::interval + interval '1 millisecond') AS window_end,
+        priority
+    FROM
+        timescaledb_osm.tiered_chunks tch
+        JOIN _timescaledb_catalog.hypertable ht ON (tch.hypertable_name = ht.table_name AND tch.hypertable_schema = ht.schema_name)
+        JOIN _timescaledb_catalog.continuous_agg cagg ON (cagg.raw_hypertable_id = ht.id)
+        JOIN _timescaledb_catalog.continuous_aggs_bucket_function bf USING (mat_hypertable_id)
+    WHERE
+        user_view_schema LIKE name_mask
+        AND user_view_name LIKE name_mask
+    ORDER BY
+        range_start;
+END
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON PROCEDURE _timescaledb_additional.schedule_osm_cagg_refresh TO pg_database_owner;
+
+COMMENT ON PROCEDURE _timescaledb_additional.schedule_osm_cagg_refresh IS
+$$schedule_osm_cagg_refresh is a pretty non-intelligent procedure.
+For the provided continuous aggregate it will write records into this table:
+    _timescaledb_additional.incremental_continuous_aggregate_refreshes
+Which will then be tasks picked up by task_refresh_continuous_aggregate_incremental_runner$$;
+
+CREATE OR REPLACE VIEW _timescaledb_additional.osm_incremental_refresh_status AS
+SELECT
+    continuous_aggregate,
+    count(*) FILTER (WHERE started IS NULL) AS "not started",
+    count(*) FILTER (WHERE started IS NOT NULL AND finished IS NULL) AS "started",
+    count(*) FILTER (WHERE started IS NOT NULL AND finished IS NOT NULL) AS "finished"
+FROM
+    _timescaledb_additional.incremental_continuous_aggregate_refreshes
+GROUP BY
+    continuous_aggregate
+ORDER BY
+    continuous_aggregate;
+
+REVOKE ALL ON TABLE _timescaledb_additional.osm_incremental_refresh_status FROM PUBLIC;
+GRANT SELECT ON TABLE _timescaledb_additional.osm_incremental_refresh_status TO public;
+GRANT ALL ON TABLE _timescaledb_additional.osm_incremental_refresh_status TO pg_database_owner;
+
+CREATE OR REPLACE VIEW _timescaledb_additional.job_cagg_refresh_status AS
+SELECT
+    clock_timestamp()::timestamptz(0),
+    pid,
+    wait_event,
+    application_name,
+    (now() - xact_start)::interval(0) AS xact_age,
+    (now() - backend_start)::interval(0) AS backend_age
+FROM
+    pg_stat_activity
+WHERE
+    state <> 'idle'
+    AND application_name LIKE '%refresh%';
+
+REVOKE ALL ON TABLE _timescaledb_additional.job_cagg_refresh_status FROM PUBLIC;
+GRANT SELECT ON TABLE _timescaledb_additional.job_cagg_refresh_status TO public;
+GRANT ALL ON TABLE _timescaledb_additional.job_cagg_refresh_status TO pg_database_owner;

--- a/utils/osm_incremental_cagg_refresh/02-consumer.sql
+++ b/utils/osm_incremental_cagg_refresh/02-consumer.sql
@@ -1,0 +1,195 @@
+DROP PROCEDURE IF EXISTS _timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner(integer, jsonb);
+CREATE PROCEDURE _timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner (
+    job_id integer,
+    config jsonb
+) LANGUAGE plpgsql AS $BODY$
+DECLARE
+    max_runtime interval := (config->>'max_runtime')::interval;
+    enable_tiered boolean := (config->>'enable_tiered_reads')::boolean;
+    global_start_time timestamptz := pg_catalog.clock_timestamp();
+    global_end_time timestamptz;
+    app_name text;
+    n_jobs_left int;
+    p_job_id int := job_id;
+BEGIN
+    max_runtime := coalesce(max_runtime, interval '1 hours');
+    global_end_time := global_start_time + max_runtime;
+
+    -- Cleanup lost tasks
+    UPDATE
+        _timescaledb_additional.incremental_continuous_aggregate_refreshes
+    SET
+        worker_pid = NULL,
+        started = NULL
+    WHERE
+        started IS NOT NULL
+        AND finished IS NULL
+        AND (NOT EXISTS (SELECT FROM pg_stat_activity WHERE pid = worker_pid) OR worker_pid IS NULL);
+
+    WHILE pg_catalog.clock_timestamp() < global_end_time LOOP
+        SET search_path TO 'pg_catalog,pg_temp';
+        SET lock_timeout TO '3s';
+        SET application_name TO 'cagg incremental refresh consumer - idle';
+
+        SET application_name TO 'cagg incremental refresh consumer - retrieving new task';
+
+        DECLARE
+            p_id bigint;
+            p_cagg regclass;
+            p_window_start timestamptz;
+            p_window_end timestamptz;
+        BEGIN
+            SELECT
+                q.id,
+                q.continuous_aggregate,
+                q.window_start,
+                q.window_end
+            INTO
+                p_id,
+                p_cagg,
+                p_window_start,
+                p_window_end
+            FROM
+                _timescaledb_additional.incremental_continuous_aggregate_refreshes AS q
+            JOIN
+                pg_catalog.pg_class AS pc ON (q.continuous_aggregate=oid)
+            JOIN
+                pg_catalog.pg_namespace AS pn ON (relnamespace=pn.oid)
+            JOIN
+                _timescaledb_catalog.continuous_agg AS cagg ON (cagg.user_view_schema=nspname AND cagg.user_view_name=pc.relname)
+            JOIN
+                _timescaledb_catalog.hypertable AS h ON (cagg.mat_hypertable_id=h.id)
+            LEFT JOIN
+                timescaledb_information.jobs ON (proc_name='policy_refresh_continuous_aggregate' AND proc_schema='_timescaledb_functions' AND jobs.config->>'mat_hypertable_id' = cagg.mat_hypertable_id::text)
+            WHERE
+                q.worker_pid IS NULL AND q.finished IS NULL
+                -- We don't want multiple workers to be active on the same CAgg,
+                AND NOT EXISTS (
+                    SELECT
+                    FROM
+                        _timescaledb_additional.incremental_continuous_aggregate_refreshes AS a
+                    JOIN
+                        pg_catalog.pg_stat_activity ON (pid=worker_pid)
+                    WHERE
+                        a.finished IS NULL
+                        -- If pids ever get recycled (container/machine restart),
+                        -- this filter ensures we ignore the old ones
+                        AND started > backend_start
+                        AND q.continuous_aggregate = a.continuous_aggregate
+                )
+            ORDER BY
+                q.priority ASC,
+                q.scheduled ASC
+            FOR UPDATE OF q SKIP LOCKED
+            LIMIT
+                1;
+
+            IF p_cagg IS NULL THEN
+                COMMIT;
+                -- There are no items in the queue that we can currently process. We therefore
+                -- sleep a while longer before attempting to try again.
+                IF global_end_time - interval '30 seconds' < now () THEN
+                    EXIT;
+                ELSE
+                    SET application_name TO 'cagg incremental refresh consumer - waiting for next task';
+                    CONTINUE;
+                END IF;                
+            END IF;
+
+            UPDATE
+                _timescaledb_additional.incremental_continuous_aggregate_refreshes
+            SET
+                worker_pid = pg_backend_pid(),
+                started = clock_timestamp()
+            WHERE
+                id = p_id;
+
+            -- Inform others of what we are doing.
+            app_name := ' refresh ' || p_window_start::date;
+            IF p_window_end::date != p_window_start::date THEN
+                app_name := app_name || ' ' || p_window_end::date;
+            ELSE
+                app_name := app_name || to_char(p_window_start, 'THH24:MI');
+            END IF;
+            IF length(app_name) + length(p_cagg::text) > 63 THEN
+                app_name := '...' || right(p_cagg::text, 60 - length(app_name)) || app_name;
+            ELSE
+                app_name := p_cagg::text || app_name;
+            END IF;
+            PERFORM pg_catalog.set_config(
+                'application_name',
+                app_name,
+                false
+            );
+
+            RAISE DEBUG
+                '% - Processing %, (% - %)',
+                pg_catalog.to_char(pg_catalog.clock_timestamp(), 'YYYY-MM-DD HH24:MI:SS.FF3OF'),
+                p_cagg,
+                p_window_start,
+                p_window_end;
+            
+            -- We need to ensure that all other workers now know we are working on this
+            -- task. We therefore need to commit once now. This also releases our
+            -- access exclusive lock on the queue table.
+            COMMIT;
+
+            -- We take out a row-level-lock to signal to concurrent workers that *we*
+            -- are working on it. By taking this type of lock, we can clean up
+            -- this table from different tasks: They can update/delete these rows
+            -- if no active worker is working on them, and no lock is established.
+            PERFORM
+            FROM
+                _timescaledb_additional.incremental_continuous_aggregate_refreshes
+            WHERE
+                id = p_id
+            FOR NO KEY UPDATE;
+
+            IF enable_tiered IS NOT NULL THEN
+                PERFORM pg_catalog.set_config(
+                    'timescaledb.enable_tiered_reads',
+                    enable_tiered::text,
+                    false
+                );
+            END IF;
+
+            CALL public.refresh_continuous_aggregate(
+                p_cagg,
+                p_window_start,
+                p_window_end
+            );
+
+            UPDATE
+                _timescaledb_additional.incremental_continuous_aggregate_refreshes
+            SET
+                finished = clock_timestamp()
+            WHERE
+                id = p_id;
+            COMMIT;
+
+            IF enable_tiered IS NOT NULL THEN
+                RESET timescaledb.enable_tiered_reads;
+            END IF;
+            SET application_name TO 'cagg incremental refresh consumer - idle';
+        END;
+    END LOOP;
+
+    -- Check if there's no range to be migrated and disable the job
+    SELECT
+        count(*)
+    INTO
+        n_jobs_left
+    FROM
+        _timescaledb_additional.incremental_continuous_aggregate_refreshes
+    WHERE
+        finished IS NULL;
+
+    IF n_jobs_left = 0 THEN
+        PERFORM public.alter_job(p_job_id, scheduled => false);
+    END IF;
+
+    RAISE NOTICE 'Shutting down worker, as we exceeded our maximum runtime (%)', max_runtime;
+END;
+$BODY$;
+
+GRANT EXECUTE ON PROCEDURE _timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner TO pg_database_owner;

--- a/utils/osm_incremental_cagg_refresh/README.md
+++ b/utils/osm_incremental_cagg_refresh/README.md
@@ -1,0 +1,107 @@
+# Incremental Continuous Aggregate Refresh on Tiered Data
+
+## Introduction
+This directory has a set of SQL procedures to create/refresh a continuous aggregates from tiered data on S3, only available on Timescale Cloud.
+
+> **IMPORTANT NOTE:**
+> This procedure only adds the **TIERED PORTION** of the hypertable's data to the continuous aggregate.
+
+We use a producer-consumer pattern to incrementally build the Continuous Aggregate from tiered data. We first identify the time range that we will refresh, split it into a bunch of smaller intervals and then start refreshing these intervals.
+
+## Producer
+The procedure `_timescaledb_additional.schedule_osm_cagg_refresh` finds the time range of the tiered data for the hypertable (corresponding to the Continuous Aggregate) and splits the range into a set of time intervals. These intervals are added to the `_timescaledb_additional.incremental_continuous_aggregate_refreshes` table.
+
+## Consumer
+The procedure `_timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner` picks the time intervals from the `_timescaledb_additional.incremental_continuous_aggregate_refreshes` table and calls `refresh_continuous_aggregate` procedure on these intervals until the list is exhausted.
+
+## How do I run this?
+
+
+### 1. Produce ranges to be refreshed:
+```sql
+CALL _timescaledb_additional.schedule_osm_cagg_refresh('myschema-name', 'mycagg-name');
+```
+
+### 2. Add a consumer job to refresh the produced ranges:
+```sql
+SELECT
+    add_job(
+        '_timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner',
+        schedule_interval => '5 seconds',
+        config => '{"enable_tiered_reads": true, "max_runtime": "5 minutes"}'
+    );
+```
+
+This call adds a job that runs in the background and refreshes the continuous aggregate.
+
+**NOTE**
+The `enable_tiered_reads = true` config is necessary if the default DB settings for `timescaleb_osm.enable_tiered_reads` GUC is `false`.
+
+### 3. Monitoring
+
+The `_timescaledb_additional.osm_incremental_refresh_status` view can be used to monitor progress of the refresh execution:
+```sql
+tsdb=> SELECT * FROM _timescaledb_additional.osm_incremental_refresh_status;
+       continuous_aggregate       | not started | started | finished 
+----------------------------------+-------------+---------+----------
+ hf_schema.cagg_data_1minute      |         256 |       0 |        3
+```
+
+`finished` shows the number of refresh time intervals that have been completed, `not started` shows how many are remaining.
+
+The `_timescaledb_additional.job_cagg_refresh_status` view can be used to check the status of the job executions (consumers):
+```sql
+tsdb=> SELECT * FROM _timescaledb_additional.job_cagg_refresh_status;
+    clock_timestamp     |  pid   |  wait_event  |                        application_name                        | xact_age | backend_age 
+------------------------+--------+--------------+----------------------------------------------------------------+----------+-------------
+ 2025-01-04 14:31:03+00 | 153087 |              | hf_schema.cagg_data_1minute refresh 2021-01-19 2021-02-18    | 00:00:10 | 00:00:44
+```
+
+## Advanced Usecase
+
+1. You can use the schedule_osm_cagg_refresh procedure to generate refresh ranges for multiple continuous aggregates.
+
+```sql
+CALL _timescaledb_additional.schedule_osm_cagg_refresh(); -- All CAggs with tiered data
+```
+
+```sql
+CALL _timescaledb_additional.schedule_osm_cagg_refresh(schema_mask => 'hf_schema'); -- All CAggs with tiered data under hf_schema 
+```
+
+```sql
+CALL _timescaledb_additional.schedule_osm_cagg_refresh(name_mask => 'cagg_data%'); -- All CAggs with name beginning with cagg_data, that appears in any schema  
+```
+
+```sql
+CALL _timescaledb_additional.schedule_osm_cagg_refresh(schema_mask => 'hf_schema%', name_mask => 'cagg_data%'); -- All CAggs with name beginning with cagg_data under schemas that begin with the name hf_schema.  
+```
+
+2. Multiple continuous aggregates can be refreshed in parallel. You can create multiple jobs like so:
+
+```sql
+SELECT
+    add_job(
+        '_timescaledb_additional.task_refresh_continuous_aggregate_incremental_runner',
+        schedule_interval => '5 seconds',
+        config => '{"enable_tiered_reads": true, "max_runtime": "5 minutes"}'
+    )
+FROM
+    generate_series(1, 4);
+```
+
+Every job is executed by a background worker. Please keep you max background worker settings and database load in mind while adding jobs so that you do not exhaust DB resources.
+
+**NOTE**  
+A Continuous Aggregate will be refreshed by exactly 1 (one) job using this framework i.e. one continuous aggregate cannot be refreshed in parallel. 
+
+The job progress can be monitored using `_timescaledb_additional.osm_incremental_refresh_status` view.
+```sql
+tsdb=> SELECT * FROM _timescaledb_additional.osm_incremental_refresh_status;
+       continuous_aggregate       | not started | started | finished
+----------------------------------+-------------+---------+----------
+ hf_schema.cagg_1minute           |         256 |       0 |        3
+ hf_schema.cagg_2_1hour           |         255 |       1 |        3
+ hf_schema.cagg_2_1minute         |         258 |       1 |       27
+```
+


### PR DESCRIPTION
This implementation intend to refresh Continuous Aggregate that are build on top of hypertables that have OSM chunks.

The architecture is a producer/consumer where the producer generate ranges based on the OSM chunks in order to the consumer job execute the actual Continuous Aggregate refresh.