### PR TITLE
Upgrade and downgrade support for the composite bloom filters

### DIFF
--- a/utils/2.26.X-downgrade-composite-bloom-columns.sql
+++ b/utils/2.26.X-downgrade-composite-bloom-columns.sql
@@ -1,0 +1,127 @@
+-- The naming scheme for the composite bloom filter metadata columns has changed in 2.27 to
+-- always include a hash of the concatenated column names, even if the concatenated column
+-- names are short. The new naming scheme uses the zero byte as a separator in the hash input,
+-- while the old scheme used underscore as separator. This caused an ambiguity in the old
+-- naming scheme where the composite filter column name was the same for ('a_b', 'c')
+-- and ('a', 'b_c'), which could lead to an error when compressing a chunk.
+--
+-- See bug report here: https://github.com/timescale/timescaledb/issues/9578
+--
+
+--
+-- This script iterates over the compression settings for the compressed chunks and
+-- checks if there are any composite bloom filters. It generates the old and the new
+-- metadata column names and verifies in the catalog that the new column name actually
+-- exists. If it does, then it renames the column to the old name.
+--
+
+--
+-- This script is provided to support downgrading from 2.27 to 2.26 so one can
+-- use the generated composite bloom filter metadata column names after the downgrade.
+-- WARNING: this script cannot handle the case when the composite bloom filter metadata
+-- column name is ambiguous under the old naming scheme, which can happen when the
+-- concatenated column names have underscores and they are clashing after concatenation.
+-- If this happens the script will fail.
+--
+
+SET timescaledb.restoring TO on;
+
+DO $$
+DECLARE
+    rename_data RECORD;
+BEGIN
+    FOR rename_data IN
+        --
+        -- Make sure the old meta name actually exists for the compressed chunk
+        -- relation, so the renaming that follows only impact real columns not
+        -- some hallucinated ones.
+        --
+        SELECT
+            att.attrelid::regclass,
+            e.old_meta_name,
+            e.new_meta_name
+        FROM
+            pg_attribute att,
+            (
+            --
+            -- Calculate the old and new metadata column names of the composite bloom filters.
+            -- Note that the new scheme always use a hash string to distinguish between the
+            -- composite columns, but the old one only used the hash if the concatenated column
+            -- names were too long.
+            --
+            SELECT
+                compress_relid,
+                CASE
+                    WHEN length(joined_cols_underscores) > 39
+                        THEN '_ts_meta_v2_bloomh_' || hash_underscores || '_' || joined_cols_underscores
+                ELSE '_ts_meta_v2_bloomh_' || joined_cols_underscores
+                END as old_meta_name,
+                '_ts_meta_v2_bloomh_' || hash_zeroes || '_' || joined_cols_underscores as new_meta_name
+            FROM
+                (
+                --
+                -- Calculate the first 4 characters of the md5 hashes of both the
+                -- zero and underscore concatenated column names of the composite
+                -- bloom filters.
+                --
+                SELECT
+                    compress_relid,
+                    substr(md5(joined_cols_zeroes),1,4) as hash_zeroes,
+                    substr(md5(joined_cols_underscores),1,4) as hash_underscores,
+                    joined_cols_underscores
+                FROM (
+                    --
+                    -- Select the compression settings objects that are actually a
+                    -- a 'bloom' filter, out of the already selected 'column' arrays
+                    -- and return the compressed chunk relation along with the column
+                    -- names concatenated with underscores as well as zeroes.
+                    --
+                    SELECT
+                        compress_relid,
+                        (SELECT string_agg(value::bytea, '\x00'::bytea) FROM jsonb_array_elements_text(cols::jsonb)) as joined_cols_zeroes,
+                        array_to_string(array(select jsonb_array_elements_text(cols::jsonb)), '_') as joined_cols_underscores
+                    FROM (
+                        --
+                        -- Select the settings where the column field is an array
+                        -- which is a must for the composite bloom filters
+                        --
+                        SELECT
+                            *,
+                            ae->>'column' cols
+                        FROM (
+                            --
+                            -- Capture the compression settings for the compressed
+                            -- tables, and separate the individual settings along
+                            -- with their types 
+                            --
+                            SELECT
+                                compress_relid::text,
+                                jsonb_array_elements(index) ae,
+                                jsonb_array_elements(index)->>'type' ty
+                            FROM _timescaledb_catalog.compression_settings
+                            WHERE compress_relid::text LIKE '%compress_hyper%'
+                        ) a
+                    WHERE jsonb_typeof(ae->'column') = 'array'
+                    ) b
+                 WHERE ty = 'bloom'
+                ) c
+            ) d
+        ) e
+        WHERE att.attrelid = e.compress_relid::regclass AND att.attname = e.new_meta_name
+    LOOP
+        RAISE NOTICE 'RENAMING: %s.%I to %I',
+            rename_data.attrelid,
+            rename_data.new_meta_name,
+            rename_data.old_meta_name;
+
+        EXECUTE format(
+            'ALTER TABLE %s RENAME COLUMN %I TO %I',
+            rename_data.attrelid,
+            rename_data.new_meta_name,
+            rename_data.old_meta_name
+        );
+    END LOOP;
+END;
+$$;
+
+RESET timescaledb.restoring;

--- a/utils/2.27.x-fix-composite-bloom-columns.sql
+++ b/utils/2.27.x-fix-composite-bloom-columns.sql
@@ -1,0 +1,125 @@
+-- The naming scheme for the composite bloom filter metadata columns has changed in 2.27 to
+-- always include a hash of the concatenated column names, even if the concatenated column
+-- names are short. The new naming scheme uses the zero byte as a separator in the hash input,
+-- while the old scheme used underscore as separator. This caused an ambiguity in the old
+-- naming scheme where the composite filter column name was the same for ('a_b', 'c')
+-- and ('a', 'b_c'), which could lead to an error when compressing a chunk.
+--
+-- See bug report here: https://github.com/timescale/timescaledb/issues/9578
+--
+
+--
+-- This script iterates over the compression settings for the compressed chunks and
+-- checks if there are any composite bloom filters. It generates the old and the new
+-- metadata column names and verifies in the catalog that the old column name actually
+-- exists. If it does, then it renames the column to the new name.
+--
+
+--
+-- Because this script verifies the existence of the old column names and verifies
+-- the compression settings to be of type bloom and being a composite filter, it
+-- is safe to run it even if the cluster has already been on 2.27 or if there are
+-- mixed data, or no composite bloom filters at all.
+--
+
+SET timescaledb.restoring TO on;
+
+DO $$
+DECLARE
+    rename_data RECORD;
+BEGIN
+    FOR rename_data IN
+        --
+        -- Make sure the old meta name actually exists for the compressed chunk
+        -- relation, so the renaming that follows only impact real columns not
+        -- some hallucinated ones.
+        --
+        SELECT
+            att.attrelid::regclass,
+            e.old_meta_name,
+            e.new_meta_name
+        FROM
+            pg_attribute att,
+            (
+            --
+            -- Calculate the old and new metadata column names of the composite bloom filters.
+            -- Note that the new scheme always use a hash string to distinguish between the
+            -- composite columns, but the old one only used the hash if the concatenated column
+            -- names were too long.
+            --
+            SELECT
+                compress_relid,
+                CASE
+                    WHEN length(joined_cols_underscores) > 39
+                        THEN '_ts_meta_v2_bloomh_' || hash_underscores || '_' || joined_cols_underscores
+                ELSE '_ts_meta_v2_bloomh_' || joined_cols_underscores
+                END as old_meta_name,
+                '_ts_meta_v2_bloomh_' || hash_zeroes || '_' || joined_cols_underscores as new_meta_name
+            FROM
+                (
+                --
+                -- Calculate the first 4 characters of the md5 hashes of both the
+                -- zero and underscore concatenated column names of the composite
+                -- bloom filters.
+                --
+                SELECT
+                    compress_relid,
+                    substr(md5(joined_cols_zeroes),1,4) as hash_zeroes,
+                    substr(md5(joined_cols_underscores),1,4) as hash_underscores,
+                    joined_cols_underscores
+                FROM (
+                    --
+                    -- Select the compression settings objects that are actually a
+                    -- a 'bloom' filter, out of the already selected 'column' arrays
+                    -- and return the compressed chunk relation along with the column
+                    -- names concatenated with underscores as well as zeroes.
+                    --
+                    SELECT
+                        compress_relid,
+                        (SELECT string_agg(value::bytea, '\x00'::bytea) FROM jsonb_array_elements_text(cols::jsonb)) as joined_cols_zeroes,
+                        array_to_string(array(select jsonb_array_elements_text(cols::jsonb)), '_') as joined_cols_underscores
+                    FROM (
+                        --
+                        -- Select the settings where the column field is an array
+                        -- which is a must for the composite bloom filters
+                        --
+                        SELECT
+                            *,
+                            ae->>'column' cols
+                        FROM (
+                            --
+                            -- Capture the compression settings for the compressed
+                            -- tables, and separate the individual settings along
+                            -- with their types 
+                            --
+                            SELECT
+                                compress_relid::text,
+                                jsonb_array_elements(index) ae,
+                                jsonb_array_elements(index)->>'type' ty
+                            FROM _timescaledb_catalog.compression_settings
+                            WHERE compress_relid::text LIKE '%compress_hyper%'
+                        ) a
+                    WHERE jsonb_typeof(ae->'column') = 'array'
+                    ) b
+                 WHERE ty = 'bloom'
+                ) c
+            ) d
+        ) e
+        WHERE att.attrelid = e.compress_relid::regclass AND att.attname = e.old_meta_name
+    LOOP
+        RAISE NOTICE 'RENAMING: %s.%I to %I',
+            rename_data.attrelid,
+            rename_data.old_meta_name,
+            rename_data.new_meta_name;
+
+        EXECUTE format(
+            'ALTER TABLE %s RENAME COLUMN %I TO %I',
+            rename_data.attrelid,
+            rename_data.old_meta_name,
+            rename_data.new_meta_name
+        );
+    END LOOP;
+END;
+$$;
+
+RESET timescaledb.restoring;


### PR DESCRIPTION
The naming scheme for the composite bloom filter metadata columns in the compressed chunks has changed because the old scheme in 2.26 was ambiguous in scenarios where the composite column names had underscores, which was also used as a separator. For this reason the new scheme uses a md5 hash calculated from the column names separated by the zero byte.

The two scripts provided allows one to rename the metadata column names. One script for upgrading from 2.26 to 2.27 and another one for downgrading from 2.27 to 2.26:

- 2.27.x-fix-composite-bloom-columns.sql
- 2.26.X-downgrade-composite-bloom-columns.sql

If the column name ambiguity does exists in the column names the downgrade will fail. One needs to drop one of the ambigous composite bloom filters before downgrading.