### PR TITLE
Add remove_materialization_ranges definition as it's used by the script but not created anywhere

### DIFF
--- a/utils/cagg_check_gaps/cagg_manual_refresh_ranges.sql
+++ b/utils/cagg_check_gaps/cagg_manual_refresh_ranges.sql
@@ -41,6 +41,16 @@ CREATE OR REPLACE VIEW public.cagg_pending_ranges AS
         AND d.interval_length IS NOT NULL
     ORDER BY ca.user_view_schema, ca.user_view_name, mr.lowest_modified_value;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.remove_materialization_ranges(mat_hypertable_id integer, start_value bigint, end_value bigint)
+ RETURNS void
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'pg_catalog', 'pg_temp'
+AS $$
+	DELETE FROM _timescaledb_catalog.continuous_aggs_materialization_ranges
+	WHERE materialization_id = mat_hypertable_id and lowest_modified_value = start_value and greatest_modified_value = end_value;
+$$
+  
 DROP FUNCTION IF EXISTS cagg_get_manual_refresh_stmt(text);
 CREATE OR REPLACE FUNCTION cagg_get_manual_refresh_stmt(cagg_name text)
 RETURNS TABLE(refresh_command text, delete_command text)


### PR DESCRIPTION
I faced many clients having issues about the same topic:
```
Query 1 ERROR at Line 111: : ERROR: function _timescaledb_functions.remove_materialization_ranges(integer, bigint, bigint) does not exist
LINE 1: SELECT _timescaledb_functions.remove_materialization_ranges(...
^
HINT: No function matches the given name and argument types. You might need to add explicit type casts.
```
Checking in their service I see the function is not there
```
tsdb=# SELECT n.nspname, p.proname, pg_get_function_arguments(p.oid)
FROM pg_proc p
JOIN pg_namespace n ON p.pronamespace = n.oid
WHERE p.proname ILIKE '%remove_material%';
 nspname | proname | pg_get_function_arguments 
---------+---------+---------------------------
(0 rows)
```

So I've added to the script itself in order to get this solve for every client that gets the script and has to run it by themselves.